### PR TITLE
Finish initialization when there are no accounts configured

### DIFF
--- a/www/app/actions/viewing.js
+++ b/www/app/actions/viewing.js
@@ -37,7 +37,7 @@ return {
     const account = mailApi.accounts.defaultAccount;
     return {
       type: SELECT_ACCOUNT,
-      accountId: account.id,
+      accountId: (account && account.id || null),
       folderType: 'inbox'
     };
   },

--- a/www/app/reducers/viewing.js
+++ b/www/app/reducers/viewing.js
@@ -209,11 +209,17 @@ return function reduceViewing(oldState = DEFAULT_STATE, action) {
   let dirtySerials = false;
   switch (action.type) {
     case SELECT_ACCOUNT: {
-      let account = mailApi.accounts.getAccountById(action.accountId);
-      let folder = account.folders.getFirstFolderWithType(action.folderType);
+      let account = action.accountId ?
+                    mailApi.accounts.getAccountById(action.accountId) :
+                    null;
+
+      let folder = action.accountId ?
+                   account.folders.getFirstFolderWithType(action.folderType) :
+                  null;
+
       newState.selections = {
-        accountId: account.id,
-        folderId: folder.id,
+        accountId: (account && account.id) || null,
+        folderId: (folder && folder.id) || null,
         conversationId: null,
         messageId: null
       };


### PR DESCRIPTION
Initial startup with no accounts was failing becuase the actions/viewing.js tried to access account.id, but the account could be undefined. These changes seemed to be enough to get the UI started up without errors in the dev console.